### PR TITLE
Add self-hosted store links for Start9 and Umbrel

### DIFF
--- a/src/pages/instructions/Start9Instructions.tsx
+++ b/src/pages/instructions/Start9Instructions.tsx
@@ -1,65 +1,74 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Box, Download, Settings, Users, CheckCircle } from 'lucide-react';
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import start9 from '../../../assets/start9-logo.png';
+import {
+  ArrowLeft,
+  Box,
+  Download,
+  Settings,
+  Users,
+  CheckCircle,
+} from "lucide-react";
 
 const Start9Instructions: React.FC = () => {
   const navigate = useNavigate();
 
   const steps = [
     {
-      title: 'Access Start9 Marketplace',
-      description: 'Open your Start9 server interface and navigate to the Marketplace',
+      title: "Access Start9 Marketplace",
+      description:
+        "Open your Start9 server interface and navigate to the Marketplace",
       icon: Box,
       details: [
-        'Open your web browser and go to your Start9 server address',
-        'Log in to your Start9 admin interface',
-        'Click on "Marketplace" in the sidebar'
-      ]
+        "Open your web browser and go to your Start9 server address",
+        "Log in to your Start9 admin interface",
+        'Click on "Marketplace" in the sidebar',
+      ],
     },
     {
-      title: 'Install Fedimint',
-      description: 'Search for and install the Fedimint service',
+      title: "Install Fedimint",
+      description: "Search for and install the Fedimint service",
       icon: Download,
       details: [
         'Search for "Fedimint" in the marketplace',
-        'Click on the Fedimint Guardian service',
+        "Click on the Fedimint Guardian service",
         'Click "Install" and wait for the installation to complete',
-        'The service will appear in your "Installed" services list'
-      ]
+        'The service will appear in your "Installed" services list',
+      ],
     },
     {
-      title: 'Configure Fedimint',
-      description: 'Set up your Fedimint guardian configuration',
+      title: "Configure Fedimint",
+      description: "Set up your Fedimint guardian configuration",
       icon: Settings,
       details: [
-        'Click on the Fedimint service from your installed services',
+        "Click on the Fedimint service from your installed services",
         'Click "Configure" to open the configuration interface',
-        'Set your guardian name and other basic settings',
-        'Note down the guardian API endpoint for sharing with other guardians'
-      ]
+        "Set your guardian name and other basic settings",
+        "Note down the guardian API endpoint for sharing with other guardians",
+      ],
     },
     {
-      title: 'Coordinate with Guardians',
-      description: 'Share connection details with other federation members',
+      title: "Coordinate with Guardians",
+      description: "Share connection details with other federation members",
       icon: Users,
       details: [
-        'Share your guardian API endpoint with other federation members',
-        'Collect API endpoints from all other guardians',
-        'Ensure all guardians are online and reachable',
-        'Coordinate a time for the federation setup ceremony'
-      ]
+        "Share your guardian API endpoint with other federation members",
+        "Collect API endpoints from all other guardians",
+        "Ensure all guardians are online and reachable",
+        "Coordinate a time for the federation setup ceremony",
+      ],
     },
     {
-      title: 'Complete Setup',
-      description: 'Run the federation setup ceremony',
+      title: "Complete Setup",
+      description: "Run the federation setup ceremony",
       icon: CheckCircle,
       details: [
-        'Access the Fedimint web interface through Start9',
-        'Follow the setup wizard to create or join a federation',
-        'Generate and securely backup your guardian keys',
-        'Verify the federation is operational with a small test transaction'
-      ]
-    }
+        "Access the Fedimint web interface through Start9",
+        "Follow the setup wizard to create or join a federation",
+        "Generate and securely backup your guardian keys",
+        "Verify the federation is operational with a small test transaction",
+      ],
+    },
   ];
 
   return (
@@ -68,7 +77,7 @@ const Start9Instructions: React.FC = () => {
       <header className="px-6 py-4">
         <div className="max-w-4xl mx-auto flex items-center">
           <button
-            onClick={() => navigate('/self-hosted')}
+            onClick={() => navigate("/self-hosted")}
             className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 transition-colors"
           >
             <ArrowLeft className="w-5 h-5" />
@@ -82,19 +91,35 @@ const Start9Instructions: React.FC = () => {
         <div className="max-w-4xl mx-auto">
           <div className="flex items-center space-x-4 mb-8">
             <div className="w-16 h-16 bg-gradient-to-br from-cyan-500 to-blue-600 rounded-xl flex items-center justify-center">
-              <Box className="w-8 h-8 text-white" />
+              <img src={start9} alt="Start9" className="w-8 h-8" />
             </div>
             <div>
               <h1 className="text-4xl font-bold text-gray-900">Start9 Setup</h1>
-              <p className="text-lg text-gray-600">Deploy Fedimint on your Start9 personal server</p>
+              <p className="text-lg text-gray-600">
+                Deploy Fedimint on your Start9 personal server
+              </p>
             </div>
           </div>
 
           {/* Prerequisites */}
           <div className="bg-cyan-50 rounded-2xl p-6 mb-8 border border-cyan-100">
-            <h2 className="text-xl font-semibold text-cyan-900 mb-3">Prerequisites</h2>
+            <h2 className="text-xl font-semibold text-cyan-900 mb-3">
+              Prerequisites
+            </h2>
             <ul className="space-y-2 text-cyan-800">
-              <li>• Start9 server running Start9OS 0.3.4 or later</li>
+              <li>
+                • Purchase a Start9 server from the{" "}
+                <a
+                  href="https://store.start9.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  official Start9 store
+                </a>
+                {' '}(~$600 - $1000)
+              </li>
+              <li>• Running Start9OS 0.3.4 or later</li>
               <li>• Admin access to your Start9 server</li>
               <li>• Stable internet connection</li>
               <li>• Contact information for other federation guardians</li>
@@ -106,27 +131,35 @@ const Start9Instructions: React.FC = () => {
             {steps.map((step, index) => {
               const IconComponent = step.icon;
               return (
-                <div key={index} className="bg-white rounded-2xl p-8 shadow-sm border border-gray-200">
+                <div
+                  key={index}
+                  className="bg-white rounded-2xl p-8 shadow-sm border border-gray-200"
+                >
                   <div className="flex items-start space-x-6">
                     <div className="flex-shrink-0">
                       <div className="w-12 h-12 bg-gradient-to-br from-cyan-500 to-blue-600 rounded-lg flex items-center justify-center">
                         <IconComponent className="w-6 h-6 text-white" />
                       </div>
                     </div>
-                    
+
                     <div className="flex-1">
                       <div className="flex items-center space-x-3 mb-3">
                         <span className="bg-cyan-100 text-cyan-800 text-sm font-medium px-3 py-1 rounded-full">
                           Step {index + 1}
                         </span>
-                        <h3 className="text-xl font-bold text-gray-900">{step.title}</h3>
+                        <h3 className="text-xl font-bold text-gray-900">
+                          {step.title}
+                        </h3>
                       </div>
-                      
+
                       <p className="text-gray-600 mb-4">{step.description}</p>
-                      
+
                       <ul className="space-y-2">
                         {step.details.map((detail, idx) => (
-                          <li key={idx} className="flex items-start space-x-2 text-gray-700">
+                          <li
+                            key={idx}
+                            className="flex items-start space-x-2 text-gray-700"
+                          >
                             <div className="w-1.5 h-1.5 bg-cyan-500 rounded-full mt-2 flex-shrink-0"></div>
                             <span>{detail}</span>
                           </li>
@@ -141,26 +174,50 @@ const Start9Instructions: React.FC = () => {
 
           {/* Additional Resources */}
           <div className="mt-12 bg-white rounded-2xl p-8 border border-gray-200 shadow-sm">
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">Additional Resources</h2>
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              Additional Resources
+            </h2>
             <div className="space-y-4">
-              <a 
-                href="https://docs.start9.com" 
-                target="_blank" 
+              <a
+                href="https://store.start9.com/"
+                target="_blank"
                 rel="noopener noreferrer"
                 className="block p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
               >
-                <h3 className="font-semibold text-gray-900">Start9 Documentation</h3>
-                <p className="text-gray-600 text-sm">Official Start9 documentation and guides</p>
+                <h3 className="font-semibold text-gray-900">
+                  Start9 Marketplace
+                </h3>
+                <p className="text-gray-600 text-sm">
+                  Browse and install services from the Start9 Marketplace
+                </p>
               </a>
-              
-              <a 
-                href="https://fedimint.org/docs" 
-                target="_blank" 
+
+              <a
+                href="https://docs.start9.com"
+                target="_blank"
                 rel="noopener noreferrer"
                 className="block p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
               >
-                <h3 className="font-semibold text-gray-900">Fedimint Documentation</h3>
-                <p className="text-gray-600 text-sm">Learn more about Fedimint federation concepts</p>
+                <h3 className="font-semibold text-gray-900">
+                  Start9 Documentation
+                </h3>
+                <p className="text-gray-600 text-sm">
+                  Official Start9 documentation and guides
+                </p>
+              </a>
+
+              <a
+                href="https://fedimint.org/docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+              >
+                <h3 className="font-semibold text-gray-900">
+                  Fedimint Documentation
+                </h3>
+                <p className="text-gray-600 text-sm">
+                  Learn more about Fedimint federation concepts
+                </p>
               </a>
             </div>
           </div>

--- a/src/pages/instructions/UmbrelInstructions.tsx
+++ b/src/pages/instructions/UmbrelInstructions.tsx
@@ -1,65 +1,72 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Umbrella, Download, Settings, Users, CheckCircle } from 'lucide-react';
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Umbrella,
+  Download,
+  Settings,
+  Users,
+  CheckCircle,
+} from "lucide-react";
 
 const UmbrelInstructions: React.FC = () => {
   const navigate = useNavigate();
 
   const steps = [
     {
-      title: 'Access Umbrel App Store',
-      description: 'Open your Umbrel dashboard and navigate to the App Store',
+      title: "Access Umbrel App Store",
+      description: "Open your Umbrel dashboard and navigate to the App Store",
       icon: Umbrella,
       details: [
-        'Open your web browser and go to your Umbrel server (usually umbrel.local)',
-        'Log in to your Umbrel dashboard',
-        'Click on "App Store" in the navigation menu'
-      ]
+        "Open your web browser and go to your Umbrel server (usually umbrel.local)",
+        "Log in to your Umbrel dashboard",
+        'Click on "App Store" in the navigation menu',
+      ],
     },
     {
-      title: 'Install Fedimint Guardian',
-      description: 'Find and install the Fedimint Guardian app',
+      title: "Install Fedimint Guardian",
+      description: "Find and install the Fedimint Guardian app",
       icon: Download,
       details: [
         'Search for "Fedimint" in the app store search bar',
-        'Click on the Fedimint Guardian app tile',
+        "Click on the Fedimint Guardian app tile",
         'Review the app details and click "Install"',
-        'Wait for the installation to complete (this may take several minutes)'
-      ]
+        "Wait for the installation to complete (this may take several minutes)",
+      ],
     },
     {
-      title: 'Initial Configuration',
-      description: 'Configure your guardian settings',
+      title: "Initial Configuration",
+      description: "Configure your guardian settings",
       icon: Settings,
       details: [
         'Once installed, click "Open" to access the Fedimint interface',
-        'Set your guardian display name and description',
-        'Configure your API endpoints and networking settings',
-        'Generate your guardian configuration and backup the seed phrase'
-      ]
+        "Set your guardian display name and description",
+        "Configure your API endpoints and networking settings",
+        "Generate your guardian configuration and backup the seed phrase",
+      ],
     },
     {
-      title: 'Federation Coordination',
-      description: 'Connect with other guardians to form the federation',
+      title: "Federation Coordination",
+      description: "Connect with other guardians to form the federation",
       icon: Users,
       details: [
-        'Share your guardian connection URL with other federation members',
-        'Collect connection URLs from all participating guardians',
-        'Verify all guardians are online and accessible',
-        'Schedule the federation setup ceremony with all members'
-      ]
+        "Share your guardian connection URL with other federation members",
+        "Collect connection URLs from all participating guardians",
+        "Verify all guardians are online and accessible",
+        "Schedule the federation setup ceremony with all members",
+      ],
     },
     {
-      title: 'Federation Setup Ceremony',
-      description: 'Complete the distributed key generation process',
+      title: "Federation Setup Ceremony",
+      description: "Complete the distributed key generation process",
       icon: CheckCircle,
       details: [
-        'Start the federation setup process from the Fedimint interface',
-        'Follow the ceremony steps to generate distributed keys',
-        'Verify the federation configuration with all guardians',
-        'Test the federation with a small transaction to ensure everything works'
-      ]
-    }
+        "Start the federation setup process from the Fedimint interface",
+        "Follow the ceremony steps to generate distributed keys",
+        "Verify the federation configuration with all guardians",
+        "Test the federation with a small transaction to ensure everything works",
+      ],
+    },
   ];
 
   return (
@@ -68,7 +75,7 @@ const UmbrelInstructions: React.FC = () => {
       <header className="px-6 py-4">
         <div className="max-w-4xl mx-auto flex items-center">
           <button
-            onClick={() => navigate('/self-hosted')}
+            onClick={() => navigate("/self-hosted")}
             className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 transition-colors"
           >
             <ArrowLeft className="w-5 h-5" />
@@ -86,18 +93,36 @@ const UmbrelInstructions: React.FC = () => {
             </div>
             <div>
               <h1 className="text-4xl font-bold text-gray-900">Umbrel Setup</h1>
-              <p className="text-lg text-gray-600">Deploy Fedimint on your Umbrel home server</p>
+              <p className="text-lg text-gray-600">
+                Deploy Fedimint on your Umbrel home server
+              </p>
             </div>
           </div>
 
           {/* Prerequisites */}
           <div className="bg-blue-50 rounded-2xl p-6 mb-8 border border-blue-100">
-            <h2 className="text-xl font-semibold text-blue-900 mb-3">Prerequisites</h2>
+            <h2 className="text-xl font-semibold text-blue-900 mb-3">
+              Prerequisites
+            </h2>
             <ul className="space-y-2 text-blue-800">
+              <li>
+                • Purchase a Umbrel server from{" "}
+                <a
+                  href="https://umbrel.com/umbrel-home"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  the official Umbrel store
+                </a>{" "}
+                (~$400)
+              </li>
               <li>• Umbrel server running Umbrel OS 1.0 or later</li>
               <li>• Sufficient storage space (at least 1GB free)</li>
               <li>• Reliable internet connection</li>
-              <li>• Bitcoin Core node (recommended, can be installed via Umbrel)</li>
+              <li>
+                • Bitcoin Core node (recommended, can be installed via Umbrel)
+              </li>
             </ul>
           </div>
 
@@ -106,27 +131,35 @@ const UmbrelInstructions: React.FC = () => {
             {steps.map((step, index) => {
               const IconComponent = step.icon;
               return (
-                <div key={index} className="bg-white rounded-2xl p-8 shadow-sm border border-gray-200">
+                <div
+                  key={index}
+                  className="bg-white rounded-2xl p-8 shadow-sm border border-gray-200"
+                >
                   <div className="flex items-start space-x-6">
                     <div className="flex-shrink-0">
                       <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg flex items-center justify-center">
                         <IconComponent className="w-6 h-6 text-white" />
                       </div>
                     </div>
-                    
+
                     <div className="flex-1">
                       <div className="flex items-center space-x-3 mb-3">
                         <span className="bg-blue-100 text-blue-800 text-sm font-medium px-3 py-1 rounded-full">
                           Step {index + 1}
                         </span>
-                        <h3 className="text-xl font-bold text-gray-900">{step.title}</h3>
+                        <h3 className="text-xl font-bold text-gray-900">
+                          {step.title}
+                        </h3>
                       </div>
-                      
+
                       <p className="text-gray-600 mb-4">{step.description}</p>
-                      
+
                       <ul className="space-y-2">
                         {step.details.map((detail, idx) => (
-                          <li key={idx} className="flex items-start space-x-2 text-gray-700">
+                          <li
+                            key={idx}
+                            className="flex items-start space-x-2 text-gray-700"
+                          >
                             <div className="w-1.5 h-1.5 bg-blue-500 rounded-full mt-2 flex-shrink-0"></div>
                             <span>{detail}</span>
                           </li>
@@ -141,37 +174,72 @@ const UmbrelInstructions: React.FC = () => {
 
           {/* Important Notes */}
           <div className="mt-12 bg-yellow-50 rounded-2xl p-8 border border-yellow-200">
-            <h2 className="text-xl font-semibold text-yellow-900 mb-4">Important Notes</h2>
+            <h2 className="text-xl font-semibold text-yellow-900 mb-4">
+              Important Notes
+            </h2>
             <ul className="space-y-2 text-yellow-800">
-              <li>• Keep your guardian seed phrase secure - it cannot be recovered if lost</li>
-              <li>• Ensure your Umbrel has a static IP or use dynamic DNS for external access</li>
-              <li>• Consider setting up Tor for enhanced privacy (available in Umbrel settings)</li>
+              <li>
+                • Keep your guardian seed phrase secure - it cannot be recovered
+                if lost
+              </li>
+              <li>
+                • Ensure your Umbrel has a static IP or use dynamic DNS for
+                external access
+              </li>
+              <li>
+                • Consider setting up Tor for enhanced privacy (available in
+                Umbrel settings)
+              </li>
               <li>• Regular backups of your Umbrel system are recommended</li>
             </ul>
           </div>
 
           {/* Additional Resources */}
           <div className="mt-8 bg-white rounded-2xl p-8 border border-gray-200 shadow-sm">
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">Additional Resources</h2>
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              Additional Resources
+            </h2>
             <div className="space-y-4">
-              <a 
-                href="https://umbrel.com/docs" 
-                target="_blank" 
+              <a
+                href="https://umbrel.com/umbrel-home"
+                target="_blank"
                 rel="noopener noreferrer"
                 className="block p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
               >
-                <h3 className="font-semibold text-gray-900">Umbrel Documentation</h3>
-                <p className="text-gray-600 text-sm">Official Umbrel setup and troubleshooting guides</p>
+                <h3 className="font-semibold text-gray-900">
+                  Umbrel App Store
+                </h3>
+                <p className="text-gray-600 text-sm">
+                  Explore apps available on Umbrel Home
+                </p>
               </a>
-              
-              <a 
-                href="https://community.umbrel.com" 
-                target="_blank" 
+
+              <a
+                href="https://umbrel.com/docs"
+                target="_blank"
                 rel="noopener noreferrer"
                 className="block p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
               >
-                <h3 className="font-semibold text-gray-900">Umbrel Community</h3>
-                <p className="text-gray-600 text-sm">Get help and support from the Umbrel community</p>
+                <h3 className="font-semibold text-gray-900">
+                  Umbrel Documentation
+                </h3>
+                <p className="text-gray-600 text-sm">
+                  Official Umbrel setup and troubleshooting guides
+                </p>
+              </a>
+
+              <a
+                href="https://community.umbrel.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+              >
+                <h3 className="font-semibold text-gray-900">
+                  Umbrel Community
+                </h3>
+                <p className="text-gray-600 text-sm">
+                  Get help and support from the Umbrel community
+                </p>
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add Start9 Marketplace link to Start9 instructions
- Add Umbrel Home App Store link to Umbrel instructions

## Test plan
- Open Start9 instructions and verify external link to https://store.start9.com/
- Open Umbrel instructions and verify external link to https://umbrel.com/umbrel-home
- Build succeeds without errors

🤖 Generated with [Claude Code](https://claude.ai/code)